### PR TITLE
feat: improve crate's API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ribbon"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Nadir Fejzic <nadirfejzo@gmail.com>"]
 description = "Tape machine for peeking through windows of iterators."

--- a/src/band.rs
+++ b/src/band.rs
@@ -28,7 +28,7 @@ where
     {
         let tape = [0; LEN].map(|_| None);
 
-        Band {
+        Band::<LEN, I> {
             iter,
             tape,
             head: 0,

--- a/src/band.rs
+++ b/src/band.rs
@@ -2,8 +2,9 @@
 
 use crate::{ribbon, Ribbon};
 
-/// A fix-sized [`Ribbon`] backed up by an array of `N` elements. It cannot grow over the given fixed
-/// length, and instead drops and/or returns items if no space is available at the given moment.
+/// A fix-sized [`Ribbon`] backed up by an array of `N` elements. It cannot grow over the given
+/// fixed length, and instead drops and/or returns items if no space is available at the given
+/// moment.
 ///
 /// [`Ribbon`]: crate::Ribbon
 #[derive(Debug)]
@@ -22,13 +23,10 @@ where
     I: Iterator,
 {
     /// Creates a new `Tape` from the given iterator.
-    pub fn new(iter: I) -> Band<LEN, I>
-    where
-        I: Iterator,
-    {
+    pub fn new(iter: I) -> Band<LEN, I> {
         let tape = [0; LEN].map(|_| None);
 
-        Band::<LEN, I> {
+        Band {
             iter,
             tape,
             head: 0,
@@ -37,6 +35,9 @@ where
     }
 
     /// Shifts all items by 1, returning the head of the `Band`.
+    ///
+    /// Shifting is a misnomer, and runs in `O(1)`. Rather than shifting elements, the indices
+    /// pointing to the first and last element are shifted.
     fn slide(&mut self) -> Option<I::Item> {
         let first = self.tape[self.head].take()?;
 
@@ -51,10 +52,13 @@ where
         self.len() == LEN
     }
 
+    /// Moves the head index by 1, wrapping around to the start of inner array when longer than
+    /// `LEN`.
     fn incr_head(&mut self) {
         self.head = (self.head + 1) % LEN;
     }
 
+    /// Calculates the tail index based on head index and length of the `Band`.
     fn tail(&self) -> usize {
         (self.head + self.len.saturating_sub(1)) % LEN
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@
 //! ### Using `Tape`
 //!
 //! ```rust
-//! use ribbon::{Ribbon, Tape};
+//! use ribbon::{Ribbon, Tape, Enroll};
 //!
-//! let mut tape = Tape::new(0..10);
+//! let mut tape = (0..10).tape();
 //! tape.expand_n(5);
 //!
 //! assert_eq!(tape.len(), 5);
@@ -36,11 +36,10 @@
 //! ### Using `Band`
 //!
 //! ```rust
-//! use ribbon::Band;
-//! use ribbon::Ribbon;
+//! use ribbon::{Band, Ribbon, Enroll};
 //!
 //! // Band with capacity for 5 items
-//! let mut band: Band<3, _> = Band::new(0..4);
+//! let mut band = (0..4).band::<3>();
 //! band.expand_n(2); // consume 0, 1 from iterator
 //!
 //! assert_eq!(band.len(), 2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! use ribbon::Ribbon;
 //!
 //! // Band with capacity for 5 items
-//! let mut band: Band<3, _, _> = Band::new(0..4);
+//! let mut band: Band<3, _> = Band::new(0..4);
 //! band.expand_n(2); // consume 0, 1 from iterator
 //!
 //! assert_eq!(band.len(), 2);

--- a/src/ribbon.rs
+++ b/src/ribbon.rs
@@ -1,3 +1,5 @@
+use crate::{Band, Tape};
+
 pub trait Ribbon<T> {
     /// Tries to stream the iterator forward through the `Ribbon` without expanding it. Underlying
     /// iterator is polled for the next element. Returns the head of the `Ribbon`, and the new item
@@ -199,5 +201,45 @@ pub trait Ribbon<T> {
     /// ```
     fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+/// Extension trait on types that implement [`Iterator`] trait with convenient functions to convert
+/// the given [`Iterator`] into a [`Band`] or [`Tape`].
+///
+/// [`Band`]: crate::Band
+/// [`Tape`]: crate::Tape
+pub trait Enroll {
+    /// Creates a new [`Band`] from the given Iterator.
+    ///
+    /// [`Band`]: crate::Band
+    fn band<const N: usize>(self) -> crate::Band<N, Self>
+    where
+        Self: Sized + Iterator;
+
+    /// Creates a new [`Tape`] from the given Iterator.
+    ///
+    /// [`Tape`]: crate::Tape
+    fn tape(self) -> crate::Tape<Self>
+    where
+        Self: Sized + Iterator;
+}
+
+impl<I> Enroll for I
+where
+    I: Iterator,
+{
+    fn band<const N: usize>(self) -> Band<N, Self>
+    where
+        Self: Sized + Iterator,
+    {
+        crate::Band::<N, Self>::new(self)
+    }
+
+    fn tape(self) -> Tape<Self>
+    where
+        Self: Sized + Iterator,
+    {
+        crate::Tape::new(self)
     }
 }

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -187,4 +187,17 @@ mod tests {
         tape.pop_back();
         assert_eq!(tape.len(), 0);
     }
+
+    #[test]
+    fn is_iterator() {
+        let mut tape = Tape::from(0..5);
+
+        assert_eq!(tape.len(), 0);
+        assert_eq!(tape.next(), Some(0));
+        assert_eq!(tape.next(), Some(1));
+        assert_eq!(tape.next(), Some(2));
+        assert_eq!(tape.next(), Some(3));
+        assert_eq!(tape.next(), Some(4));
+        assert_eq!(tape.next(), None);
+    }
 }

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -4,6 +4,8 @@
 
 use std::collections::VecDeque;
 
+use crate::Ribbon;
+
 /// A dynamically sized [`Ribbon`] that can hold varying number of items and can grow and shrink as
 /// necessary. It is backed up by a [`VecDeque`], and allocates memory on the heap (as is customary by
 /// dynamically sized collections)
@@ -76,6 +78,30 @@ where
 
     fn len(&self) -> usize {
         self.tape.len()
+    }
+}
+
+impl<I> From<I> for Tape<I>
+where
+    I: Iterator,
+{
+    fn from(value: I) -> Self {
+        Tape::new(value)
+    }
+}
+
+impl<I> Iterator for Tape<I>
+where
+    I: Iterator,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_empty() {
+            self.expand();
+        }
+
+        self.pop_front()
     }
 }
 

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -11,16 +11,22 @@ use std::collections::VecDeque;
 /// [`VecDeque`]: std::collections::VecDeque
 /// [`Ribbon`]: crate::Ribbon
 #[derive(Debug)]
-pub struct Tape<I, T> {
+pub struct Tape<I>
+where
+    I: Iterator,
+{
     iter: I,
-    tape: VecDeque<T>,
+    tape: VecDeque<I::Item>,
 }
 
-impl<I, T> Tape<I, T> {
+impl<I> Tape<I>
+where
+    I: Iterator,
+{
     /// Creates a new `Tape` from the given iterator.
-    pub fn new(iter: I) -> Tape<I, T>
+    pub fn new(iter: I) -> Tape<I>
     where
-        I: Iterator<Item = T>,
+        I: Iterator,
     {
         Tape {
             iter,
@@ -29,11 +35,11 @@ impl<I, T> Tape<I, T> {
     }
 }
 
-impl<I, T> super::ribbon::Ribbon<T> for Tape<I, T>
+impl<I> super::ribbon::Ribbon<I::Item> for Tape<I>
 where
-    I: Iterator<Item = T>,
+    I: Iterator,
 {
-    fn progress(&mut self) -> Option<T> {
+    fn progress(&mut self) -> Option<I::Item> {
         let next = self.iter.next()?;
 
         let head = self.pop_front();
@@ -48,23 +54,23 @@ where
         }
     }
 
-    fn pop_front(&mut self) -> Option<T> {
+    fn pop_front(&mut self) -> Option<I::Item> {
         self.tape.pop_front()
     }
 
-    fn peek_front(&self) -> Option<&T> {
+    fn peek_front(&self) -> Option<&I::Item> {
         self.tape.front()
     }
 
-    fn pop_back(&mut self) -> Option<T> {
+    fn pop_back(&mut self) -> Option<I::Item> {
         self.tape.pop_back()
     }
 
-    fn peek_back(&self) -> Option<&T> {
+    fn peek_back(&self) -> Option<&I::Item> {
         self.tape.back()
     }
 
-    fn peek_at(&self, index: usize) -> Option<&T> {
+    fn peek_at(&self, index: usize) -> Option<&I::Item> {
         self.tape.get(index)
     }
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -31,3 +31,22 @@ fn test_band() {
     // iterator does not produce more values, progress becomes no-op.
     assert_eq!(band.progress(), None);
 }
+
+#[test]
+fn test_enroll() {
+    use ribbon::Enroll;
+
+    let iter = 0..10;
+
+    let mut tape = iter.tape();
+    tape.expand_n(5);
+    assert_eq!(tape.progress(), Some(0));
+    assert_eq!(tape.peek_at(2), Some(&3));
+
+    let iter = 0..10;
+
+    let mut band = iter.band::<5>();
+    band.expand_n(3);
+    assert_eq!(band.progress(), Some(0));
+    assert_eq!(band.progress(), Some(1));
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -17,7 +17,7 @@ fn test_band() {
     use ribbon::Band;
 
     // Band with capacity for 5 items
-    let mut band: Band<3, _, _> = Band::new(0..4);
+    let mut band: Band<3, _> = Band::new(0..4);
     band.expand_n(2); // consume 0, 1 from iterator
 
     assert_eq!(band.len(), 2);


### PR DESCRIPTION
Add an extension trait to extend `Iterator` implementations, so that `Band` and `Tape` can be created by calling a corresponding function on any type that implements `Iterator` trait. 

Also, remove redundant generic type parameters on `Band` and `Tape`. 